### PR TITLE
[issue168] create storybook skeleton of NavItem

### DIFF
--- a/components/Nav/NavItem.tsx
+++ b/components/Nav/NavItem.tsx
@@ -2,7 +2,7 @@ import Link from "next/link"
 import styles from "./NavPrimary.module.css"
 import { IPage } from "../../data/pages"
 
-interface NavItemProps {
+export interface NavItemProps {
 	page: IPage
 	activeNavLink: string
 	handleNavClick?: () => void

--- a/stories/NavItem.stories.tsx
+++ b/stories/NavItem.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { ComponentStory, ComponentMeta } from "@storybook/react"
+import NavItem, { NavItemProps } from "../components/Nav/NavItem"
+import { pages } from "../data/pages"
+
+export default {
+	title: "Example/NavItem",
+	component: NavItem,
+} as ComponentMeta<typeof NavItem>
+
+const Template: ComponentStory<typeof NavItem> = (args) => <NavItem {...args} />
+
+export const DesktopNavItem = Template.bind({})
+
+DesktopNavItem.args = {
+	page: pages[16],
+	activeNavLink: "/navigation",
+} as NavItemProps


### PR DESCRIPTION
Signed-off-by: huluvu424242 <huluvu424242@gmail.com>

## Describe your changes
add an skeleton for the storybook entry of NavItem

## Screenshots - If Any (Optional)
Example page
![image](https://user-images.githubusercontent.com/1297475/196044288-273eb8ae-b55b-4421-9cde-ae9306d9acd7.png)

Example page with lighthouse test
![image](https://user-images.githubusercontent.com/1297475/196044796-a376547c-a956-41c8-bd51-48dd6951d66c.png)

## Link to issue
<!-- Example: Closes #31 -->
Closes #168 

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [no] I ran the app and tested it locally to verify that it works as expected.
- [98%] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
## Additional Information (Optional)

I need an hint. This codes is not valid in my mind but i dont have an idea for an page (IPage). 
Additionally the lighthouse report meets only 98% for a11y. But this is the second problem. 


<a href="https://gitpod.io/#https://github.com/AccessibleForAll/AccessibleWebDev/pull/169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

