### PR TITLE
Refactor maintainer data and types into own file

### DIFF
--- a/components/MaintainerCard/MaintainerCard.tsx
+++ b/components/MaintainerCard/MaintainerCard.tsx
@@ -1,15 +1,15 @@
 /* eslint-disable @next/next/no-img-element */
 import styles from "./MaintainerCard.module.css"
+import { IMaintainer } from "../../data/maintainers"
 
 export interface MaintainerCardProps {
-	image: string
-	fullName: string
-	description: string
-	githubLink: string
+	maintainer: IMaintainer
 }
 
 export const MaintainerCard = (props: MaintainerCardProps) => {
-	const { image, fullName, description, githubLink } = props
+	const {
+		maintainer: { image, fullName, description, githubLink },
+	} = props
 
 	return (
 		<section className={styles.maintainerContainer}>

--- a/data/maintainers.ts
+++ b/data/maintainers.ts
@@ -1,0 +1,23 @@
+export interface IMaintainer {
+	image: string
+	fullName: string
+	description: string
+	githubLink: string
+}
+
+export const currentMaintainers: IMaintainer[] = [
+	{
+		image: "https://github.com/emmadawsondev.png",
+		fullName: "Emma Dawson",
+		description:
+			"Emma is a full stack developer from Stockholm with a passion for accessibility and open source. She wants to make web accessibility easy to learn for everyone.",
+		githubLink: "https://github.com/EmmaDawsonDev",
+	},
+	{
+		image: "https://github.com/ctoffanin.png",
+		fullName: "Cristian Toffanin",
+		description:
+			"Cristian is a full stack developer based in the Netherlands. He's always curious and always learning. He's currently learning about accessibility (Emma's mentee).",
+		githubLink: "https://github.com/ctoffanin",
+	},
+]

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -7,14 +7,15 @@ import {
 	MaintainerCard,
 	MaintainerCardProps,
 } from "../components/MaintainerCard/MaintainerCard"
+import { currentMaintainers, IMaintainer } from "../data/maintainers"
 import styles from "../styles/about.module.css"
 
 interface AboutProps {
-	maintainerData: MaintainerCardProps[]
+	currentMaintainerData: IMaintainer[]
 }
 
 const About: NextPage = (props) => {
-	const { maintainerData } = props as AboutProps
+	const { currentMaintainerData } = props as AboutProps
 	const { t } = useTranslation("common")
 
 	return (
@@ -30,8 +31,8 @@ const About: NextPage = (props) => {
 				<section>
 					<h2>Current Maintainers</h2>
 					<div className={styles.aboutRow}>
-						{maintainerData.map((maintainer, index) => (
-							<MaintainerCard key={index} {...maintainer} />
+						{currentMaintainerData.map((maintainer, index) => (
+							<MaintainerCard key={index} maintainer={maintainer} />
 						))}
 					</div>
 				</section>
@@ -43,28 +44,13 @@ const About: NextPage = (props) => {
 export const getStaticProps: GetStaticProps = async (context) => {
 	const locale: string = context.locale!
 
-	const maintainerData: MaintainerCardProps[] = [
-		{
-			image: "https://github.com/emmadawsondev.png",
-			fullName: "Emma Dawson",
-			description:
-				"Emma is a full stack developer from Stockholm with a passion for accessibility and open source. She wants to make web accessibility easy to learn for everyone.",
-			githubLink: "https://github.com/EmmaDawsonDev",
-		},
-		{
-			image: "https://github.com/ctoffanin.png",
-			fullName: "Cristian Toffanin",
-			description:
-				"Cristian is a full stack developer based in the Netherlands. He's always curious and always learning. He's currently learning about accessibility (Emma's mentee).",
-			githubLink: "https://github.com/ctoffanin",
-		},
-	]
+	const currentMaintainerData = currentMaintainers
 
 	return {
 		props: {
 			...(await serverSideTranslations(locale, ["common"])),
 			// Will be passed to the page component as props
-			maintainerData: maintainerData,
+			currentMaintainerData: currentMaintainerData,
 		},
 	}
 }


### PR DESCRIPTION
## Describe your changes
Moved maintainer data into it's own file and created a new IMaintainer type which can be used in both About page and Maintainer Card component. Renamed maintainerData to currentMaintainerData in case we have maintainers that leave in the future then a pastMaintainderData array can be added too.



- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave
      and it shows no errors.



<a href="https://gitpod.io/#https://github.com/AccessibleForAll/AccessibleWebDev/pull/201"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

