### PR TITLE
Fix: Update props in maintainerCard component

### DIFF
--- a/components/MaintainerCard/MaintainerCard.tsx
+++ b/components/MaintainerCard/MaintainerCard.tsx
@@ -6,12 +6,8 @@ export interface IMaintainerCardProps {
 	maintainer: IMaintainer
 }
 
-export const MaintainerCard = ({
-	image,
-	fullName,
-	description,
-	githubLink,
-}: IMaintainer) => {
+export const MaintainerCard = ({ maintainer }: IMaintainerCardProps) => {
+	const { image, fullName, description, githubLink } = maintainer
 	return (
 		<section className={styles.maintainerContainer}>
 			{image ? (

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -3,10 +3,7 @@ import { Layout } from "../components/Layout/Layout"
 import Head from "next/head"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
-import {
-	MaintainerCard,
-	IMaintainerCardProps,
-} from "../components/MaintainerCard/MaintainerCard"
+import { MaintainerCard } from "../components/MaintainerCard/MaintainerCard"
 import { currentMaintainers, IMaintainer } from "../data/maintainers"
 import styles from "../styles/about.module.css"
 


### PR DESCRIPTION
## Describe your changes
The recent PR to update interfaces and props accidentally broke the about page. This PR fixes the props in MaintainerCard so that the about page works again.



## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [ ] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
