### PR TITLE
Fix: Update interface names in storybook files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,10 +23,10 @@
 			"rules": {
 				"react/prop-types": "off",
 				"@typescript-eslint/naming-convention": [
-					"error",
+					"warn",
 					{
 						"selector": "default",
-						"format": ["strictCamelCase"],
+						"format": ["camelCase"],
 						"leadingUnderscore": "forbid",
 						"trailingUnderscore": "forbid"
 					},

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { Header, HeaderProps } from "../components/Header/Header"
+import { Header, IHeaderProps } from "../components/Header/Header"
 
 export default {
 	title: "Example/Header",
@@ -15,4 +15,5 @@ DesktopHeader.args = {
 	headerTitle: "Page Title",
 	handleNavClick: () => true,
 	showNavMobile: false,
-} as HeaderProps
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+} as IHeaderProps

--- a/stories/MaintainerCard.stories.tsx
+++ b/stories/MaintainerCard.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react"
 
 import {
 	MaintainerCard,
-	MaintainerCardProps,
+	IMaintainerCardProps,
 } from "../components/MaintainerCard/MaintainerCard"
 
 export default {
@@ -26,4 +26,5 @@ const maintainer = {
 	githubLink: "https://github.com",
 }
 
-DesktopMaintainerCard.args = { maintainer } as MaintainerCardProps
+// eslint-disable-next-line @typescript-eslint/naming-convention
+DesktopMaintainerCard.args = { maintainer } as IMaintainerCardProps

--- a/stories/NavItem.stories.tsx
+++ b/stories/NavItem.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { NavItem, NavItemProps } from "../components/Nav/NavItem"
+import { NavItem, INavItemProps } from "../components/Nav/NavItem"
 import { pages } from "../data/pages"
 
 export default {
@@ -15,4 +15,5 @@ export const DesktopNavItem = Template.bind({})
 DesktopNavItem.args = {
 	page: pages[16],
 	activeNavLink: "/navigation",
-} as NavItemProps
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+} as INavItemProps

--- a/stories/NavPrimary.stories.tsx
+++ b/stories/NavPrimary.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { NavPrimary, NavProps } from "../components/Nav/NavPrimary"
+import { NavPrimary, INavProps } from "../components/Nav/NavPrimary"
 
 export default {
 	title: "Example/Nav",
@@ -15,4 +15,5 @@ export const PrimaryNav = Template.bind({})
 
 PrimaryNav.args = {
 	activeNavLink: "/",
-} as NavProps
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+} as INavProps

--- a/stories/NavPrimaryMobile.stories.tsx
+++ b/stories/NavPrimaryMobile.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { ComponentStory, ComponentMeta } from "@storybook/react"
-import { NavPrimaryMobile, NavProps } from "../components/Nav/NavPrimaryMobile"
+import { NavPrimaryMobile, INavProps } from "../components/Nav/NavPrimaryMobile"
 
 export default {
 	title: "Example/Nav",
@@ -16,4 +16,5 @@ export const MobilePrimaryNav = Template.bind({})
 MobilePrimaryNav.args = {
 	activeNavLink: "/",
 	handleNavClick: () => true,
-} as NavProps
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+} as INavProps


### PR DESCRIPTION
The updated naming conventions for interface props had been missed in the stories, causing the app not to build.
