### PR TITLE
Feat/add react syntax highlighter

### DIFF
--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -1,12 +1,15 @@
-import styles from "./CodeBlock.module.css"
 interface ICodeBlockProps {
 	codeSnippet: string
+	languageType: string
 }
+const defaultType = "html" // default syntaxhighliter argument set as html
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
+import { dracula } from "react-syntax-highlighter/dist/cjs/styles/prism"
 
-export const CodeBlock = ({ codeSnippet }: ICodeBlockProps) => {
+export const CodeBlock = ({ codeSnippet, languageType }: ICodeBlockProps) => {
 	return (
-		<pre className={styles.codeWrapper}>
-			<code>{codeSnippet}</code>
-		</pre>
+		<SyntaxHighlighter language={languageType || defaultType} style={dracula}>
+			{codeSnippet}
+		</SyntaxHighlighter>
 	)
 }

--- a/components/ContentTemplates/ButtonsTemplate.tsx
+++ b/components/ContentTemplates/ButtonsTemplate.tsx
@@ -118,8 +118,7 @@ export const ButtonsTemplate = () => {
 					languageType={"css"}
 				/>
 				<CodeBlock
-					codeSnippet={`
-<button type="button" onclick="handleClick()">Add to basket
+					codeSnippet={`<button type="button" onclick="handleClick()">Add to basket
 	<span class="visibly-hidden">Product 1</span>
 </button>`}
 					languageType={"html"}

--- a/components/ContentTemplates/ButtonsTemplate.tsx
+++ b/components/ContentTemplates/ButtonsTemplate.tsx
@@ -35,6 +35,7 @@ export const ButtonsTemplate = () => {
 
 				<CodeBlock
 					codeSnippet={`<button type="submit" onclick="handleClick()"></button>`}
+					languageType={"html"}
 				/>
 				<p>
 					If another element is used to create a button instead, such as a div,
@@ -56,6 +57,7 @@ export const ButtonsTemplate = () => {
 				</button>
 				<CodeBlock
 					codeSnippet={`<button type="button" onclick="handleClick()">Text here</button>`}
+					languageType={"html"}
 				/>
 				<p>
 					It gets its accessible name from the text between the opening and
@@ -112,11 +114,15 @@ export const ButtonsTemplate = () => {
 	position: absolute;
 	white-space: nowrap; 
 	width: 1px;
-}
-					
+}`}
+					languageType={"css"}
+				/>
+				<CodeBlock
+					codeSnippet={`
 <button type="button" onclick="handleClick()">Add to basket
 	<span class="visibly-hidden">Product 1</span>
 </button>`}
+					languageType={"html"}
 				/>
 				<p>
 					This would then read out "Add to basket product 1" to screen reader
@@ -131,6 +137,7 @@ export const ButtonsTemplate = () => {
 				<p>We could also use an aria-label.</p>
 				<CodeBlock
 					codeSnippet={`<button type="button" onclick="handleClick()" aria-label="Add to basket product 1">Add to basket</button>`}
+					languageType={"html"}
 				/>
 				<p>
 					Again, it is important that the start of the aria-label matches with
@@ -158,12 +165,14 @@ export const ButtonsTemplate = () => {
 	<img src="icon-url.png" alt="" />
 		Text
 </button>`}
+					languageType={"html"}
 				/>
 				<CodeBlock
 					codeSnippet={`<button type="button" onclick="handleClick()">
 	<img src="icon-url.png" aria-hidden="true" />
 		Text
 </button>`}
+					languageType={"html"}
 				/>
 				<p>
 					An empty alt attribute has the most wide-spread support so that should
@@ -190,11 +199,13 @@ export const ButtonsTemplate = () => {
 					codeSnippet={`<button type="button" onclick="handleClick()">
 	<img src="icon-url.png" alt="Save" />
 </button>`}
+					languageType={"html"}
 				/>
 				<CodeBlock
 					codeSnippet={`<button type="button" onclick="handleClick()">
 	<i class="fa-solid fa-floppy-disk" aria-label="Save"></i>
 </button>`}
+					languageType={"html"}
 				/>
 				<p>
 					Make sure that the label you give the icon matches the function of the
@@ -207,6 +218,7 @@ export const ButtonsTemplate = () => {
 					codeSnippet={`<button type="button" onclick="handleClick()">
 	<i class="fa-solid fa-magnifying-glass" aria-label="Search"></i>
 </button>`}
+					languageType={"html"}
 				/>
 				<p>
 					<strong>Don't do this:</strong>
@@ -215,6 +227,7 @@ export const ButtonsTemplate = () => {
 					codeSnippet={`<button type="button" onclick="handleClick()">
 	<i class="fa-solid fa-magnifying-glass" aria-label="Magnifying glass"></i>
 </button>`}
+					languageType={"html"}
 				/>
 			</TemplateSection>
 			<TemplateSection sectionName="buttonStates" title="Button States">
@@ -305,6 +318,7 @@ export const ButtonsTemplate = () => {
 				</button>
 				<CodeBlock
 					codeSnippet={`<button type="button" onclick="handleClick()" disabled>Disabled button</button>`}
+					languageType={"html"}
 				/>
 				<h3>Toggle buttons - pressed and unpressed states</h3>
 				<p>
@@ -320,6 +334,7 @@ export const ButtonsTemplate = () => {
 				</p>
 				<CodeBlock
 					codeSnippet={`<button type="button" onclick="handleClick()" aria-pressed="true">Toggle button</button>`}
+					languageType={"html"}
 				/>
 				<h3>Menus and popups - expanded and collapsed state</h3>
 				<p>
@@ -333,6 +348,7 @@ export const ButtonsTemplate = () => {
 				</p>
 				<CodeBlock
 					codeSnippet={`<button type="button" onclick="handleClick()" aria-expanded="true">Button with popup</button>`}
+					languageType={"html"}
 				/>
 			</TemplateSection>
 			<TemplateSection sectionName="buttonOrLink" title="Button or Link?">

--- a/components/ContentTemplates/ImagesTemplate.tsx
+++ b/components/ContentTemplates/ImagesTemplate.tsx
@@ -43,6 +43,7 @@ export const ImagesTemplate = () => {
 					</p>
 					<CodeBlock
 						codeSnippet={`<img src="url" alt="The text alternative goes here" />`}
+						languageType={"html"}
 					/>
 
 					<CodeBlock
@@ -50,6 +51,7 @@ export const ImagesTemplate = () => {
 	<title>The text alternative goes here</title>
 	<path d="M120 10 L55 200 L265 180 Z" />
 </svg>`}
+						languageType={"html"}
 					/>
 				</TemplateSection>
 				<TemplateSection
@@ -83,6 +85,7 @@ export const ImagesTemplate = () => {
 					<CodeBlock
 						codeSnippet={`<img src="/oldPaperTexture.jpg" alt="" />
 <img src="/hexagonsPattern.jpg" alt="" />`}
+						languageType={"html"}
 					/>
 				</TemplateSection>
 
@@ -107,6 +110,7 @@ export const ImagesTemplate = () => {
 					</div>
 					<CodeBlock
 						codeSnippet={`<img src="/cupcakes.jpg" alt="Cupcakes with pink icing and small sugar heart decorations" />`}
+						languageType={"html"}
 					/>
 
 					<h3>Complex Informative Images</h3>
@@ -138,6 +142,7 @@ export const ImagesTemplate = () => {
 					</div>
 					<CodeBlock
 						codeSnippet={`<img src="drill-instructions.png" alt="How to use a handheld drill. Further instructions below." />`}
+						languageType={"html"}
 					/>
 				</TemplateSection>
 
@@ -170,6 +175,7 @@ export const ImagesTemplate = () => {
 					<CodeBlock
 						codeSnippet={`<img src="searchBtn.png" alt="Search" />
 <img src="playBtn.png" alt="Play" />`}
+						languageType={"html"}
 					/>
 				</TemplateSection>
 
@@ -267,6 +273,7 @@ export const ImagesTemplate = () => {
 					</div>
 					<CodeBlock
 						codeSnippet={`<img src="make-the-day-great.jpg" alt="Make the day great sign" />`}
+						languageType={"html"}
 					/>
 				</TemplateSection>
 				<TemplateSection
@@ -342,6 +349,7 @@ export const ImagesTemplate = () => {
 	src="donut-coffee.png"
 	alt="Illustration of a pink doughnut with sprinkles next to a cup of black coffee" 
 />`}
+						languageType={"html"}
 					/>
 				</TemplateSection>
 				{/* TODO: <TemplateSection sectionName="checklist"  title="Images Checklist">

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.4.0",
+    "react-syntax-highlighter": "^15.5.0",
     "usehooks-ts": "^2.7.2"
   },
   "devDependencies": {
@@ -34,6 +35,7 @@
     "@types/node": "18.0.5",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
+    "@types/react-syntax-highlighter": "^15.5.6",
     "@typescript-eslint/eslint-plugin": "^5.44.0",
     "babel-loader": "^8.2.5",
     "eslint": "8.20.0",


### PR DESCRIPTION
## Describe your changes
1. Added [react-syntax-highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter) library for color syntax on all code snippet blocks
2. Configured extra prop (languageType) for choosing syntax highlight based on particular language (html/css/js/jsx/etc)
3. Configured Dracula Theme for best Accessibility stats.

## Screenshots - 
### Before 
![image](https://user-images.githubusercontent.com/88548999/218975991-e5b4e7ec-bb1c-4528-95ee-04bf7c97a964.png)

### After
![image](https://user-images.githubusercontent.com/88548999/218979990-51dd5673-71ce-4a4e-8831-88b2418a99a1.png)

## Link to issue
<!-- Example: Closes #31 -->
Closes #255 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
## Additional Information (Optional)
I found CodeBlock.module.css had no use anymore (maybe it can be removed, leaving that decision to you 😃 ), but yeah with this changes added, @mithindev should be able to do finish his Issue with ease
