### PR TITLE
using wraplongLines prop for mobile responsiveness

### DIFF
--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -15,7 +15,10 @@ interface ICodeBlockProps {
 
 export const CodeBlock = ({ codeSnippet, languageType }: ICodeBlockProps) => {
 	return (
-		<SyntaxHighlighter language={languageType} style={dracula}>
+		<SyntaxHighlighter
+			language={languageType}
+			style={dracula}
+			wrapLongLines={true}>
 			{codeSnippet}
 		</SyntaxHighlighter>
 	)


### PR DESCRIPTION
## Describe your changes
* Added wrapLongLines prop in SyntaxHighlighter Element
* Improves code readability and responsiveness for Mobile Devices

## Screenshots - If Any (Optional)
<p align="center">
<img src = "https://user-images.githubusercontent.com/88548999/221410907-ca973bc4-8bfc-4ca7-bb55-32b85e855cc2.png" alt = "" width="350" height= "700"/>
<img src = "https://user-images.githubusercontent.com/88548999/221411063-d3826855-9e8c-4884-8e5e-fc63522e7b31.png" alt = "" width="350" height= "700"/>
</p>

## Link to issue
<!-- Example: Closes #31 -->
Closes #264 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
## Additional Information (Optional)
* The Extension used to showcase those screenshots is [Mobile Simulator]((https://chrome.google.com/webstore/detail/mobile-simulator-responsi/ckejmhbmlajgoklhgbapkiccekfoccmk)
* I have a bit of feeling to check for the horizontal scroll that persists after using wrapLongLines prop.
