### PR TITLE
add: copy code block button to code snippet sections

### DIFF
--- a/components/CodeBlock/CodeBlock.module.css
+++ b/components/CodeBlock/CodeBlock.module.css
@@ -1,0 +1,3 @@
+.codeBlock {
+	position: relative;
+}

--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -1,5 +1,6 @@
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
 import { dracula } from "react-syntax-highlighter/dist/cjs/styles/prism"
+import CopyCodeBlock from "../CopyCodeBlock/CopyCodeBlock"
 
 type TCodeLanguage =
 	| "html"
@@ -15,11 +16,15 @@ interface ICodeBlockProps {
 
 export const CodeBlock = ({ codeSnippet, languageType }: ICodeBlockProps) => {
 	return (
-		<SyntaxHighlighter
-			language={languageType}
-			style={dracula}
-			wrapLongLines={true}>
-			{codeSnippet}
-		</SyntaxHighlighter>
+		<div style={{ position: "relative" }}>
+			<CopyCodeBlock code={codeSnippet} />
+			<SyntaxHighlighter
+				language={languageType}
+				style={dracula}
+				wrapLongLines={true}
+				className="contain">
+				{codeSnippet}
+			</SyntaxHighlighter>
+		</div>
 	)
 }

--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -1,7 +1,9 @@
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
 import { dracula } from "react-syntax-highlighter/dist/cjs/styles/prism"
 import CopyCodeBlock from "../CopyCodeBlock/CopyCodeBlock"
+import style from "./CodeBlock.module.css"
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 type TCodeLanguage =
 	| "html"
 	| "css"
@@ -16,7 +18,7 @@ interface ICodeBlockProps {
 
 export const CodeBlock = ({ codeSnippet, languageType }: ICodeBlockProps) => {
 	return (
-		<div style={{ position: "relative" }}>
+		<div className={style.codeBlock}>
 			<CopyCodeBlock code={codeSnippet} />
 			<SyntaxHighlighter
 				language={languageType}

--- a/components/CopyCodeBlock/CopyCodeBlock.tsx
+++ b/components/CopyCodeBlock/CopyCodeBlock.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react"
+import { FaCopy, FaCheckSquare } from "react-icons/fa"
+import style from "./copyCodeBlock.module.css"
+
+interface CodeSnippet {
+	code: string
+}
+
+const CopyCodeBlock = ({ code }: CodeSnippet) => {
+	const [copyOk, setCopyOk] = useState(false)
+
+	const iconColor = copyOk ? "#0af20a" : "#ddd"
+
+	const handleClick = () => {
+		navigator.clipboard.writeText(code)
+
+		setCopyOk(true)
+		setTimeout(() => {
+			setCopyOk(false)
+		}, 500)
+	}
+
+	return (
+		<button
+			className={copyOk ? `${style.codeCopied}` : style.codeCopyBtn}
+			onClick={handleClick}
+			aria-label="Copy code snippet to clipboard">
+			{copyOk ? (
+				<FaCheckSquare style={{ color: iconColor }} />
+			) : (
+				<FaCopy style={{ color: iconColor }} />
+			)}
+		</button>
+	)
+}
+
+export default CopyCodeBlock

--- a/components/CopyCodeBlock/CopyCodeBlock.tsx
+++ b/components/CopyCodeBlock/CopyCodeBlock.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { FaCopy, FaCheckSquare } from "react-icons/fa"
-import style from "./copyCodeBlock.module.css"
+import style from "./CopyCodeBlock.module.css"
 
 interface CodeSnippet {
 	code: string
@@ -9,26 +9,30 @@ interface CodeSnippet {
 const CopyCodeBlock = ({ code }: CodeSnippet) => {
 	const [copyOk, setCopyOk] = useState(false)
 
-	const iconColor = copyOk ? "#0af20a" : "#ddd"
-
 	const handleClick = () => {
 		navigator.clipboard.writeText(code)
 
 		setCopyOk(true)
 		setTimeout(() => {
 			setCopyOk(false)
-		}, 500)
+		}, 3000)
 	}
 
 	return (
 		<button
-			className={copyOk ? `${style.codeCopied}` : style.codeCopyBtn}
+			className={style.codeCopyBtn}
 			onClick={handleClick}
 			aria-label="Copy code snippet to clipboard">
 			{copyOk ? (
-				<FaCheckSquare style={{ color: iconColor }} />
+				<>
+					<FaCheckSquare className={style.faCopSymbol} />
+					<span className={style.cpyText}>copied</span>
+				</>
 			) : (
-				<FaCopy style={{ color: iconColor }} />
+				<>
+					<FaCopy className={style.faCopySymbol} />
+					<span className={style.cpyText}>copy</span>
+				</>
 			)}
 		</button>
 	)

--- a/components/CopyCodeBlock/copyCodeBlock.module.css
+++ b/components/CopyCodeBlock/copyCodeBlock.module.css
@@ -1,0 +1,51 @@
+/* Styles for the button before being clicked */
+
+.codeCopyBtn {
+	color: white;
+	position: absolute;
+	right: 5px;
+	top: 5px;
+	font-size: 1rem;
+	cursor: pointer;
+	transition: all 0.3s ease-in-out;
+}
+
+.codeCopyBtn:hover {
+	transform: scale(1.1);
+	opacity: 0.9;
+}
+
+.codeCopyBtn:hover::after {
+	content: "copy";
+	display: flex;
+	align-items: center;
+	font-size: 0.5rem;
+	opacity: 0.9;
+}
+
+.codeCopyBtn:focus::after {
+	content: "copy";
+	display: flex;
+	align-items: center;
+	font-size: 0.5rem;
+	opacity: 0.9;
+}
+
+/* Styles for button after it has been clicked */
+.codeCopied {
+	color: white;
+	position: absolute;
+	right: 5px;
+	top: 5px;
+	font-size: 1rem;
+	cursor: pointer;
+	transition: all 0.3s ease-in-out;
+}
+
+.codeCopied::after {
+	content: "copied";
+	display: flex;
+	align-items: center;
+	font-size: 0.5rem;
+	opacity: 0.9;
+}

--- a/components/CopyCodeBlock/copyCodeBlock.module.css
+++ b/components/CopyCodeBlock/copyCodeBlock.module.css
@@ -1,8 +1,12 @@
-/* Styles for the button before being clicked */
-
 .codeCopyBtn {
-	color: white;
+	color: var(--text);
+	background-color: var(--lightGrey);
 	position: absolute;
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	border: none;
+	border-radius: 0.3rem;
 	right: 5px;
 	top: 5px;
 	font-size: 1rem;
@@ -15,37 +19,10 @@
 	opacity: 0.9;
 }
 
-.codeCopyBtn:hover::after {
-	content: "copy";
-	display: flex;
-	align-items: center;
-	font-size: 0.5rem;
-	opacity: 0.9;
+.faCopySymbol {
+	color: var(--text);
 }
 
-.codeCopyBtn:focus::after {
-	content: "copy";
-	display: flex;
-	align-items: center;
-	font-size: 0.5rem;
-	opacity: 0.9;
-}
-
-/* Styles for button after it has been clicked */
-.codeCopied {
-	color: white;
-	position: absolute;
-	right: 5px;
-	top: 5px;
+.cpyText {
 	font-size: 1rem;
-	cursor: pointer;
-	transition: all 0.3s ease-in-out;
-}
-
-.codeCopied::after {
-	content: "copied";
-	display: flex;
-	align-items: center;
-	font-size: 0.5rem;
-	opacity: 0.9;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,7 +30,7 @@ body {
 	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
 		Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 	color: var(--text);
-	background-color: var(--bg)
+	background-color: var(--bg);
 }
 
 a {
@@ -67,7 +67,11 @@ main {
 	display: none;
 }
 
-h2, h3, h4, h5, h6 {
+h2,
+h3,
+h4,
+h5,
+h6 {
 	margin: 0;
 }
 
@@ -104,14 +108,10 @@ p {
 	display: block;
 }
 
-
 .orderedLists > li {
-	margin-bottom: .7rem;
+	margin-bottom: 0.7rem;
 }
 
 .unorderedLists > li {
-	margin-bottom: .7rem;
+	margin-bottom: 0.7rem;
 }
-
-
-


### PR DESCRIPTION
## Describe your changes

Added a copy and paste button to code snippets. The button's symbol will change on click. It will display "copy" text on hover and focus and "copied" on click. Is aria-labelled so should also be accessible for screen-readers. Have tested pages with Axe Devtools and found no issues.

## Screenshots - If Any (Optional)
<img width="500" alt="copy and paste button for code snippet sections" src="https://user-images.githubusercontent.com/88390425/232722974-6754d2c1-1814-4341-a3d9-ef5eade2d9bc.png">

## Link to issue
<!-- Example: Closes #31 -->
Closes #256

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [X] I ran the app and tested it locally to verify that it works as expected.
- [X] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
## Additional Information (Optional)
Any additional information that you want to give us.
