### PR TITLE
Change link in WorkInProgress component to Github Discussions

### DIFF
--- a/components/WorkInProgress/WorkInProgress.tsx
+++ b/components/WorkInProgress/WorkInProgress.tsx
@@ -5,7 +5,7 @@ export const WorkInProgress = () => {
 		<section className={styles.WIPContainer}>
 			<h2>This section is a work in progress</h2>
 			<p>Please come back at a later date.</p>
-			<a href="https://github.com/AccessibleForAll/AccessibleWebDev">
+			<a href="https://github.com/AccessibleForAll/AccessibleWebDev/discussions">
 				Let us know what information you're looking for.
 			</a>
 		</section>


### PR DESCRIPTION
## Describe your changes
Changed the href of the "Let us know what information you're looking for" link in the WorkInProgress component. It now leads to the Discussions page (https://github.com/AccessibleForAll/AccessibleWebDev/discussions), rather than the main page of the repo. 

## Link to issue
Closes #277

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [X] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.

## Additional Information (Optional)
N/A
