### PR TITLE
Changed WCAGCriteria list style to normal template

### DIFF
--- a/components/ContentTemplates/HeadingsTemplate.tsx
+++ b/components/ContentTemplates/HeadingsTemplate.tsx
@@ -110,22 +110,16 @@ export const HeadingsTemplate = () => {
 					</ul>
 				</TemplateSection>
 				<TemplateSection sectionName="WCAGCriteria" title="WCAG Criteria">
-					<ul className="unorderedLists">
-						<li>
-							<a
-								href="https://www.w3.org/TR/WCAG21/#section-headings"
-								className="blockLink">
-								2.4.10 Section Headings
-							</a>
-						</li>
-						<li>
-							<a
-								href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html"
-								className="blockLink">
-								2.4.6 Headings and Labels
-							</a>
-						</li>
-					</ul>
+					<a
+						href="https://www.w3.org/TR/WCAG21/#section-headings"
+						className="blockLink">
+						2.4.10 Section Headings
+					</a>
+					<a
+						href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html"
+						className="blockLink">
+						2.4.6 Headings and Labels
+					</a>
 				</TemplateSection>
 				<TemplateSection
 					sectionName="QuizQuestions"


### PR DESCRIPTION
## Describe your changes
Changed **WCAGCriteria** in **Accessible Headings** page, list style to normal template for uniform theme.

## Screenshots - If Any (Optional)
### Before Changes
![Screenshot (17)](https://user-images.githubusercontent.com/98175646/233896737-200cbbfe-9ec3-4e63-9435-c2113438c52b.png)

### After changes
![Screenshot (15)](https://user-images.githubusercontent.com/98175646/233896722-3f515afb-cb80-4daf-8a71-e637c70e9492.png)

## Link to issue
https://github.com/AccessibleForAll/AccessibleWebDev/issues/283#issue-1680158408
Closes #283 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
