### PR TITLE
Add keyboard accessibility to code block

### DIFF
--- a/components/CodeBlock/CodeBlock.tsx
+++ b/components/CodeBlock/CodeBlock.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react"
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter"
 import { nightOwl } from "react-syntax-highlighter/dist/cjs/styles/prism"
 import CopyCodeBlock from "../CopyCodeBlock/CopyCodeBlock"
@@ -16,13 +17,29 @@ interface ICodeBlockProps {
 }
 
 export const CodeBlock = ({ codeSnippet, languageType }: ICodeBlockProps) => {
+	const [scrollableRegion, setScrollableRegion] = useState(false)
+
+	const ref = useRef<HTMLPreElement>(null)
+	const PreWithRef = (preProps: React.HTMLAttributes<HTMLPreElement>) => (
+		<pre {...preProps} ref={ref} />
+	)
+
+	useEffect(() => {
+		if (ref.current) {
+			const element = ref.current
+			setScrollableRegion(element.clientWidth < element.scrollWidth)
+		}
+	}, [])
+
 	return (
 		<div className={style.CodeBlockContainer}>
 			<CopyCodeBlock code={codeSnippet} />
 			<SyntaxHighlighter
 				language={languageType}
 				style={nightOwl}
-				className={style.CodeBlock}>
+				className={style.CodeBlock}
+				PreTag={PreWithRef}
+				tabIndex={scrollableRegion ? 0 : -1}>
 				{codeSnippet}
 			</SyntaxHighlighter>
 		</div>


### PR DESCRIPTION
## Describe your changes
Added a ref to the Pre block in the react syntax highlighter so that scrollbars can be detected. Adds a tab index when scrollbars are present in order to allow keyboard users to scroll horizontally.

## Screenshots - If Any (Optional)

## Link to issue
<!-- Example: Closes #31 -->
Closes #306 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
## Additional Information (Optional)
Any additional information that you want to give us.
