### PR TITLE
fix: removed redundant 'open in new tab' icons from links in footer

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -17,20 +17,14 @@ export const Footer = () => {
 						<a
 							href="https://github.com/AccessibleForAll/AccessibleWebDev/blob/main/CONTRIBUTING.md"
 							className={styles.footerLink}>
-							Become a Contributor{" "}
-							<span>
-								<BsBoxArrowUpRight aria-label="opens in new window" />
-							</span>
+							Become a Contributor
 						</a>
 					</li>
 					<li>
 						<a
 							href="https://github.com/sponsors/EmmaDawsonDev"
 							className={styles.footerLink}>
-							Support Us{" "}
-							<span>
-								<BsBoxArrowUpRight aria-label="opens in new window" />
-							</span>
+							Support Us
 						</a>
 					</li>
 					<li>


### PR DESCRIPTION
## Describe your changes
Footer links like "Become a contributor" and "Support us" are supposed to open in same tab. But current production version have open in new tab icon beside them which is misleading. This PR includes the changes to remove these icons from these 2 links

## Screenshots - If Any (Optional)
Before -
<img width="1785" alt="Screenshot 2023-07-08 at 4 51 23 PM" src="https://github.com/AccessibleForAll/AccessibleWebDev/assets/17885747/65a36728-40f4-4a44-92c7-8f9698cf7a42">
 
After - 
<img width="1788" alt="Screenshot 2023-07-08 at 4 51 41 PM" src="https://github.com/AccessibleForAll/AccessibleWebDev/assets/17885747/e348a427-4ce1-4320-83c4-3e0c53b75b0d">

## Link to issue
<!-- Example: Closes #31 -->
Closes #341 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.

