### PR TITLE
fix: Nav link state for screen readers

### DIFF
--- a/components/Nav/NavItem.tsx
+++ b/components/Nav/NavItem.tsx
@@ -13,13 +13,15 @@ export const NavItem = ({
 	activeNavLink,
 	handleNavClick,
 }: INavItemProps) => {
+	const isLinkActive = activeNavLink === page.href
 	return (
-		<li
-			className={`${styles.navListItem} ${
-				activeNavLink === page.href ? "active" : ""
-			}`}>
+		<li className={`${styles.navListItem} ${isLinkActive ? "active" : ""}`}>
 			<Link href={page.href}>
-				<a onClick={handleNavClick}>{page.name}</a>
+				<a
+					onClick={handleNavClick}
+					aria-current={isLinkActive ? "page" : false}>
+					{page.name}
+				</a>
 			</Link>
 		</li>
 	)


### PR DESCRIPTION

## Describe your changes
Added aria-current to anchor tags in NavItem component. if link is active then, set the value of aria-current to be "page" else set it to false.

## Link to issue
<!-- Example: Closes #31 -->
Closes #343

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.

