### PR TITLE
fix: color contrast of active nav link item when hovered

### DIFF
--- a/components/Nav/NavPrimary.module.css
+++ b/components/Nav/NavPrimary.module.css
@@ -33,6 +33,7 @@
 
 .navListItem a:hover {
   background-color: var(--primaryLt);
+  color: var(--text);
 }
 
 .navList a:focus {


### PR DESCRIPTION
## Describe your changes
added css color property on nav link item in hover state to be of value var(--text)

## Screenshots - If Any (Optional)
<img width="1785" alt="Screenshot 2023-07-16 at 12 11 19 AM" src="https://github.com/AccessibleForAll/AccessibleWebDev/assets/17885747/7da95c25-078f-4742-8085-532866aced17">

## Link to issue
Closes #351

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] Followed the repository's [Contributing Guidelines](/CONTRIBUTING.md).
- [x] I ran the app and tested it locally to verify that it works as expected.
- [x] I have checked my code with an automatic accessibility tool such as Axe Dev Tools or Wave 
      and it shows no errors.
